### PR TITLE
Support Python 3

### DIFF
--- a/countries/models.py
+++ b/countries/models.py
@@ -1,6 +1,10 @@
+from __future__ import unicode_literals
+
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class Country(models.Model):
     name = models.CharField(max_length=200)
     code = models.CharField(max_length=2, unique=True)
@@ -9,6 +13,5 @@ class Country(models.Model):
         ordering = ('name',)
         verbose_name_plural = 'countries'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
-


### PR DESCRIPTION
- Make the **unicode** call compatible with both python 2
  and 3 by way of the @python_2_unicode_compatible decorator.

@meshy, @NoLogo - review please?
